### PR TITLE
Engfabiom/fix/css

### DIFF
--- a/index.html
+++ b/index.html
@@ -825,14 +825,10 @@
       <p>Copyright © Oriane Royon Da Silva</p>
     </footer>
 
-    <!-- <script
-      src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"
-      integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL"
-      crossorigin="anonymous"
-    ></script> -->
     <script src="./public/scripts/index.js"></script>
     <script src="./public/scripts/main-navbar.js" type="module"></script>
     <script src="./public/scripts/paintings.js"></script>
     <script src="./public/scripts/carousel.js"></script>
+
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -248,18 +248,21 @@
                 j’aspire à plus d’énergie qu’il m’attrape de ses pattes poilues
                 pour me garder au chaud, dans un sommeil pesant et triste.
               </p>
-              <p>
-                Le petit ours est doux et moelleux. Sa fourrure sent bon comme les
-                jours de pluie. Mais la tristesse qui m’envahit est immense, et
-                aucun sommeil ne pourrait m’en consoler. Je dors plus que plus
-                soif, étourdie de tant dormir. Les yeux collés, les oreilles
-                encotonnées, je m’efface. Ne me parviennent que des remous
-                indistincts depuis le fond d’une baignoire d’eau tiédasse. Dormir
-                pour oublier comme d’autres boivent pour vivre. Cette petite boule
-                de poils, léthargique, me protège du froid incisif, de mes pensées
-                incisives, des incisions en tout genre. Anesthésiée, tout est
-                embrouillé et moi je veux juste qu’on me laisse dormir.
-              </p>
+              <details>
+                <summary>read more...</summary>
+                <p>
+                  Le petit ours est doux et moelleux. Sa fourrure sent bon comme les
+                  jours de pluie. Mais la tristesse qui m’envahit est immense, et
+                  aucun sommeil ne pourrait m’en consoler. Je dors plus que plus
+                  soif, étourdie de tant dormir. Les yeux collés, les oreilles
+                  encotonnées, je m’efface. Ne me parviennent que des remous
+                  indistincts depuis le fond d’une baignoire d’eau tiédasse. Dormir
+                  pour oublier comme d’autres boivent pour vivre. Cette petite boule
+                  de poils, léthargique, me protège du froid incisif, de mes pensées
+                  incisives, des incisions en tout genre. Anesthésiée, tout est
+                  embrouillé et moi je veux juste qu’on me laisse dormir.
+                </p>
+              </details>
             </div>
           </article>
           <article id="girafe" class="girafe portrait">
@@ -287,22 +290,25 @@
                 elle soit si loin du sol qu’on devine à peine ses drôles de
                 cornes.
               </p>
-              <p>
-                Elle m’accompagne dans les moments de confusion, quand les idées
-                s’entrechoquent sans arriver à leur terme, quand la pelote de
-                pensée s’emmêle, quand ma vie intérieure est réduite à une
-                bouillie de nœuds. Ma géante délicate m’emporte pour dépasser,
-                tenir bon, enjamber. Elle respire au-dessus de l’orage, comme on
-                tient sa tête à la surface quand on ne sait pas nager :
-                maladroitement et en avalant beaucoup d’eau.
-              </p>
-              <p>
-                Des souvenirs fous comme des oiseaux blessés se heurtent à la
-                vitre des immeubles où je m’abrite. Mais peu importe. Ce qui est
-                décisif, avec une girafe, c’est de conserver une bonne hauteur
-                sous plafond. Tant pis pour le verre brisé. Je reprendrai mon
-                souffle dans l’accalmie qu’elle m’aura permis d’aller chercher.
-              </p>
+              <details>
+                <summary>read more...</summary>
+                <p>
+                  Elle m’accompagne dans les moments de confusion, quand les idées
+                  s’entrechoquent sans arriver à leur terme, quand la pelote de
+                  pensée s’emmêle, quand ma vie intérieure est réduite à une
+                  bouillie de nœuds. Ma géante délicate m’emporte pour dépasser,
+                  tenir bon, enjamber. Elle respire au-dessus de l’orage, comme on
+                  tient sa tête à la surface quand on ne sait pas nager :
+                  maladroitement et en avalant beaucoup d’eau.
+                </p>
+                <p>
+                  Des souvenirs fous comme des oiseaux blessés se heurtent à la
+                  vitre des immeubles où je m’abrite. Mais peu importe. Ce qui est
+                  décisif, avec une girafe, c’est de conserver une bonne hauteur
+                  sous plafond. Tant pis pour le verre brisé. Je reprendrai mon
+                  souffle dans l’accalmie qu’elle m’aura permis d’aller chercher.
+                </p>
+              </details>
             </div>
           </article>
           <article id="hippopotame" class="hippopotame landscape">
@@ -327,39 +333,42 @@
                 m’arrête et que je me mets à l’écoute de mon monde intérieur, des
                 hurlements remontent de mon plexus vers ma gorg
               </p>
-              <p>
-                Longtemps l’origine de ces vibrations est restée mystérieuse. Il a
-                fallu d’abord se livrer à une paléontologie de la souffrance,
-                strate après strate, pour libérer les émotions fossilisées. La
-                rébellion recouvrait la tristesse, la tristesse enveloppit la
-                colère, la colère dissimulait la peur, et finalement sous la peur
-                : il y avait la honte. Des vagues de honte profondes et
-                renversantes, qui se déversaient, sans début ni fin, depuis la
-                gueule ouverte de l’Hippopotame.
-              </p>
-              <p>
-                Ma honte est comme une couleur primaire, qui imprègne toutes les
-                autres. Elle jaillit en une source que rien ne peut tarir depuis
-                les entrailles du traumatisme. Elle s’écoule et glougloute en un
-                long vomissement. Parfois (rarement) elle recouvre tout le reste.
-                Le plus souvent elle s’épanche en sous-terrain.
-              </p>
-              <p>
-                C’est une honte-racine, une honte-source, une honte-existentielle.
-                Comme le premier animal sur terre. Comme si avant elle rien
-                n’existait. L’Hippopotame a précédé le monde dans lequel je
-                grandis. Elle est la doyenne de tous mes animaux : la version
-                préhistorique, le protozoaire de mon bestiaire.
-              </p>
-              <p>
-                Or, à quoi ça sert la honte ? La culpabilité je vois bien : c’est
-                un moteur pour agir. Je me sens coupable de FAIRE quelque chose
-                alors je peux changer mon comportement. Mais là honte … C’est la
-                honte d’ETRE qui je suis ? A quoi sert-elle si ce n’est à se plier
-                à l’ordre de la domination sociale ? Et dans ce cas, comment
-                donner du sens, comment entendre de la beauté dans les cris
-                déchirants de mon Hippopotame ?
-              </p>
+              <details>
+                <summary>read more...</summary>
+                <p>
+                  Longtemps l’origine de ces vibrations est restée mystérieuse. Il a
+                  fallu d’abord se livrer à une paléontologie de la souffrance,
+                  strate après strate, pour libérer les émotions fossilisées. La
+                  rébellion recouvrait la tristesse, la tristesse enveloppit la
+                  colère, la colère dissimulait la peur, et finalement sous la peur
+                  : il y avait la honte. Des vagues de honte profondes et
+                  renversantes, qui se déversaient, sans début ni fin, depuis la
+                  gueule ouverte de l’Hippopotame.
+                </p>
+                <p>
+                  Ma honte est comme une couleur primaire, qui imprègne toutes les
+                  autres. Elle jaillit en une source que rien ne peut tarir depuis
+                  les entrailles du traumatisme. Elle s’écoule et glougloute en un
+                  long vomissement. Parfois (rarement) elle recouvre tout le reste.
+                  Le plus souvent elle s’épanche en sous-terrain.
+                </p>
+                <p>
+                  C’est une honte-racine, une honte-source, une honte-existentielle.
+                  Comme le premier animal sur terre. Comme si avant elle rien
+                  n’existait. L’Hippopotame a précédé le monde dans lequel je
+                  grandis. Elle est la doyenne de tous mes animaux : la version
+                  préhistorique, le protozoaire de mon bestiaire.
+                </p>
+                <p>
+                  Or, à quoi ça sert la honte ? La culpabilité je vois bien : c’est
+                  un moteur pour agir. Je me sens coupable de FAIRE quelque chose
+                  alors je peux changer mon comportement. Mais là honte … C’est la
+                  honte d’ETRE qui je suis ? A quoi sert-elle si ce n’est à se plier
+                  à l’ordre de la domination sociale ? Et dans ce cas, comment
+                  donner du sens, comment entendre de la beauté dans les cris
+                  déchirants de mon Hippopotame ?
+                </p>
+              </details>
             </div>
           </article>
           <article id="lemuriens" class="lemuriens landscape">
@@ -391,29 +400,32 @@
                 j’imagine hostiles avant même qu’ils ne m’aient adressé un regard
                 : mon enthousiasme se heurte au groupe des lémuriens.
               </p>
-              <p>
-                Je suis hors-champ. J’observe le groupe soudé de mes pairs, avec
-                convoitise, avec amertume et angoisse, avec dédain aussi, et
-                surtout, le ventre noué d’effroi. J’en déteste l’inertie, les
-                lenteurs, le conformisme, la soumission, les normes. Je suis trop
-                rigide pour me fondre dans la masse. Trop indocile aussi pour
-                encaisser les contraintes du nombre. Je souffre de la distance
-                mais ne supporte pas la proximité. Dans les fêtes d’anniversaire,
-                je fais du lèche-vitrine sans le sou, jusqu’à m’en ulcérer
-                l’estomac.
-              </p>
-              <p>
-                La horde est soudée. Je n’en fais pas partie. Seule paria, je ne
-                sais pas y faire. La dissociation monte, devient de l’angoisse et
-                nourrit le sentiment que quelque chose de grave va arriver. C’est
-                presque une parano. Autour de moi : des courses-poursuites
-                d’enfants survoltés, des cris aigus, les rires des adultes
-                éméchés, leur haleine alcoolisée, les cheveux collés de
-                transpiration, la poigne mauvaise qui saisit un petit au collet
-                pour le rudoyer, des pleurs, des claquements de porte, des menaces
-                de punitions ineptes, des pleurs de nouveau. Me voilà revenue,
-                immergée, au temps du trauma. Il faut fuir.
-              </p>
+              <details>
+                <summary>read more...</summary>
+                <p>
+                  Je suis hors-champ. J’observe le groupe soudé de mes pairs, avec
+                  convoitise, avec amertume et angoisse, avec dédain aussi, et
+                  surtout, le ventre noué d’effroi. J’en déteste l’inertie, les
+                  lenteurs, le conformisme, la soumission, les normes. Je suis trop
+                  rigide pour me fondre dans la masse. Trop indocile aussi pour
+                  encaisser les contraintes du nombre. Je souffre de la distance
+                  mais ne supporte pas la proximité. Dans les fêtes d’anniversaire,
+                  je fais du lèche-vitrine sans le sou, jusqu’à m’en ulcérer
+                  l’estomac.
+                </p>
+                <p>
+                  La horde est soudée. Je n’en fais pas partie. Seule paria, je ne
+                  sais pas y faire. La dissociation monte, devient de l’angoisse et
+                  nourrit le sentiment que quelque chose de grave va arriver. C’est
+                  presque une parano. Autour de moi : des courses-poursuites
+                  d’enfants survoltés, des cris aigus, les rires des adultes
+                  éméchés, leur haleine alcoolisée, les cheveux collés de
+                  transpiration, la poigne mauvaise qui saisit un petit au collet
+                  pour le rudoyer, des pleurs, des claquements de porte, des menaces
+                  de punitions ineptes, des pleurs de nouveau. Me voilà revenue,
+                  immergée, au temps du trauma. Il faut fuir.
+                </p>
+              </details>
             </div>
           </article>
           <article id="panthere" class="panthere portrait landscape">
@@ -442,39 +454,42 @@
                 est tabou de dire, mais pas de commettre, qui arrive sans crier
                 gare, feutrée comme les pattes d’un félin.
               </p>
-              <p>
-                Elle anime chaque cellule de mon corps, chaque électron de mon
-                cerveau. L’agitation qui guette sous ma peau, m’étreint la gorge,
-                accélère ma respiration, mon pouls, ma tension sanguine, ma
-                pression cardiaque. C’est la peur qui guette. C’est la peur qui
-                m’agite. Je cours comme une animale traquée, anesthésiée pour ne
-                pas ressentir. J’ai au fond de moi gravée : l’horreur.
-              </p>
-              <p>
-                En pensant ces mots, se réveillent des douleurs dans ma chair.
-                Plaquée par un corps d’adulte, j’étouffe. Mes clavicules brulent.
-                Mes os n’ont pas cédé sous son poids. Des sanglots se taisent dans
-                ma gorge. Alors j’ai planqué ma terreur de bête traquée.
-                Ensevelie.
-              </p>
-              <p>
-                Mais viens là, ma panthère, laisse-moi respirer. Viens là que je
-                te reconnaisse, que je t’apprivoise. Et dis-moi : qui es-tu ?
-                Est-ce que tu es le monstre dévorant, ou plutôt la bête traquée ?
-                La panthère FAIT peur autant qu’elle A peur ? C’est l’agresseur,
-                ou c’est la proie ? C’est lui, ou c’est moi ?
-              </p>
-              <p>
-                Mais viens là, ma panthère, et ensemble nous irons pisser sur sa
-                tombe. Je suis vivante et il est mort. Alors nous guérirons nos
-                clavicules et nous sauverons notre enfant intérieure de ce
-                purgatoire où elle était tombée comme dans l’eau croupie d’un
-                puit.
-              </p>
-              <p>
-                Sois sage, ô ma Terreur et tiens-toi si tranquille que je puisse
-                vivre sans y penser sans cesse.
-              </p>
+              <details>
+                <summary>read more...</summary>
+                <p>
+                  Elle anime chaque cellule de mon corps, chaque électron de mon
+                  cerveau. L’agitation qui guette sous ma peau, m’étreint la gorge,
+                  accélère ma respiration, mon pouls, ma tension sanguine, ma
+                  pression cardiaque. C’est la peur qui guette. C’est la peur qui
+                  m’agite. Je cours comme une animale traquée, anesthésiée pour ne
+                  pas ressentir. J’ai au fond de moi gravée : l’horreur.
+                </p>
+                <p>
+                  En pensant ces mots, se réveillent des douleurs dans ma chair.
+                  Plaquée par un corps d’adulte, j’étouffe. Mes clavicules brulent.
+                  Mes os n’ont pas cédé sous son poids. Des sanglots se taisent dans
+                  ma gorge. Alors j’ai planqué ma terreur de bête traquée.
+                  Ensevelie.
+                </p>
+                <p>
+                  Mais viens là, ma panthère, laisse-moi respirer. Viens là que je
+                  te reconnaisse, que je t’apprivoise. Et dis-moi : qui es-tu ?
+                  Est-ce que tu es le monstre dévorant, ou plutôt la bête traquée ?
+                  La panthère FAIT peur autant qu’elle A peur ? C’est l’agresseur,
+                  ou c’est la proie ? C’est lui, ou c’est moi ?
+                </p>
+                <p>
+                  Mais viens là, ma panthère, et ensemble nous irons pisser sur sa
+                  tombe. Je suis vivante et il est mort. Alors nous guérirons nos
+                  clavicules et nous sauverons notre enfant intérieure de ce
+                  purgatoire où elle était tombée comme dans l’eau croupie d’un
+                  puit.
+                </p>
+                <p>
+                  Sois sage, ô ma Terreur et tiens-toi si tranquille que je puisse
+                  vivre sans y penser sans cesse.
+                </p>
+              </details>
             </div>
           </article>
           <article id="rhinoceros" class="rhinoceros landscape">
@@ -504,41 +519,44 @@
                 vigoureusement tenir tête. J’en suis capable grâce à la puissance
                 archaïque de ma Rhinocéros.
               </p>
-              <p>
-                De sa peau épaisse et ridée, monumentale, elle pare aux menaces.
-                Elle est garde-barrière et garde-malade, celle qui fait le vide
-                autour de mon centre spongieux pour protéger ce qui est mien. Des
-                brisures de l’enfance malmenées elle est le bouclier, le totem et
-                la cuirasse. Retenue par aucune arrière-pensée, imperméable à la
-                culpabilité, à la honte, aux regrets. Elle est la sagesse de la
-                limite que je ne saurais poser sans elle.
-              </p>
-              <p>
-                Au travail certain.es collègues me redoutent, au sport certaines
-                personnes m’évitent. Je ne m’en plains pas, je préfère qu’on me
-                laisse tranquille, car je suis au fond très vulnérable et j’ai
-                besoin de me sentir protégée. Lorsqu’on me pousse dans mes
-                retranchements (qui sont parfois faciles à trouver), une corne
-                pointe, des sabots raclent le sol, je suis lestée de la majesté
-                d’une tonne de muscle. Je fonce dans le tas. La colosse rugueuse
-                surgit et charge sans préavis, ce qui peut être assez
-                déconcertant, je le concède à celles et ceux qui s’en sont
-                plaint.es.
-              </p>
-              <p>
-                D'ailleurs si elle charge un peu trop vite, un peu trop fort, ça
-                fout la pagaille dans l’équilibre zoologique interne. Sur le
-                moment, portée par son énergie réfractaire, je suis pure sérénité
-                et force. « Déso pas déso, c’est la Rhinocéros qui refuse de se
-                laisser marcher sur les pieds ». Et puis, à mesure qu’elle se
-                retire, j’évalue l’ampleur de son apparition. Dans certains cas,
-                je m’en mords les doigts. Je ne sais plus si oui, si non. J’aurais
-                du, c’est trop tard ? La prochaine fois... Et je dois gérer la
-                moitié de mon bestiaire en PLS : la louve grimpe dans les tours,
-                la limace se terre, la petite hippopotame manque de se noyer dans
-                ses larmes, la panthère menace de tout casser. Heureusement, la
-                scarabée que rien ne saurait dérouter prend le relai.
-              </p>
+              <details>
+                <summary>read more...</summary>
+                <p>
+                  De sa peau épaisse et ridée, monumentale, elle pare aux menaces.
+                  Elle est garde-barrière et garde-malade, celle qui fait le vide
+                  autour de mon centre spongieux pour protéger ce qui est mien. Des
+                  brisures de l’enfance malmenées elle est le bouclier, le totem et
+                  la cuirasse. Retenue par aucune arrière-pensée, imperméable à la
+                  culpabilité, à la honte, aux regrets. Elle est la sagesse de la
+                  limite que je ne saurais poser sans elle.
+                </p>
+                <p>
+                  Au travail certain.es collègues me redoutent, au sport certaines
+                  personnes m’évitent. Je ne m’en plains pas, je préfère qu’on me
+                  laisse tranquille, car je suis au fond très vulnérable et j’ai
+                  besoin de me sentir protégée. Lorsqu’on me pousse dans mes
+                  retranchements (qui sont parfois faciles à trouver), une corne
+                  pointe, des sabots raclent le sol, je suis lestée de la majesté
+                  d’une tonne de muscle. Je fonce dans le tas. La colosse rugueuse
+                  surgit et charge sans préavis, ce qui peut être assez
+                  déconcertant, je le concède à celles et ceux qui s’en sont
+                  plaint.es.
+                </p>
+                <p>
+                  D'ailleurs si elle charge un peu trop vite, un peu trop fort, ça
+                  fout la pagaille dans l’équilibre zoologique interne. Sur le
+                  moment, portée par son énergie réfractaire, je suis pure sérénité
+                  et force. « Déso pas déso, c’est la Rhinocéros qui refuse de se
+                  laisser marcher sur les pieds ». Et puis, à mesure qu’elle se
+                  retire, j’évalue l’ampleur de son apparition. Dans certains cas,
+                  je m’en mords les doigts. Je ne sais plus si oui, si non. J’aurais
+                  du, c’est trop tard ? La prochaine fois... Et je dois gérer la
+                  moitié de mon bestiaire en PLS : la louve grimpe dans les tours,
+                  la limace se terre, la petite hippopotame manque de se noyer dans
+                  ses larmes, la panthère menace de tout casser. Heureusement, la
+                  scarabée que rien ne saurait dérouter prend le relai.
+                </p>
+              </details>
             </div>
           </article>
           <article id="scarabee" class="scarabee landscape">
@@ -569,56 +587,59 @@
                 professionnelles vite et bien, avec intérêt, engagement, avec de
                 l’endurance aussi.
               </p>
-              <p>
-                Je suis obstinée. J’abats les taches qu’on me confie. Je fais même
-                ce que j’avais dit que je refusais de faire, mais je le fais quand
-                même rattrapée par ma culpabilité congénitale. Bref, j’en fais
-                beaucoup trop, et c’est la scarabée qui me conduit sur ce chemin.
-                Pour tenir le trauma à distance, pour maintenir l’illusion d’un
-                quotidien performant et l’apparence bien ficelée de la normalité.
-              </p>
-              <p>
-                Elle pousse une boule d’émotions résultant du traumatisme. Elle
-                incarne ma détermination à m’agiter pour ne pas laisser les
-                émotions (la peur, la honte, et la tristesse) me pétrifier. Ses
-                pattes griffues s’arqueboutent sur une sphère plus grosse et plus
-                lourde qu’elle-même. Les pattes avant campent dans le sol,
-                cherchent de meilleures prises pour se propulser ; les pattes
-                arrière roulent sur la boule pour la déplacer. Petit pas par petit
-                pas, avec opiniâtreté et une forme d’aveuglement d’autant qu’elle
-                ne progresse qu’à reculons. Imperturbable Sysiphe à 6 pattes, elle
-                pousse ce rocher, et pousse, et pousse et pousse, sans fin, sans
-                but. Il est juste impossible de s’arrêter.
-              </p>
-              <p>
-                La pelote de trauma luit du vermeil d’un volcan ensommeillé, une
-                chaleur diffuse s’en dégage qui brule le bout des pattes du petit
-                insecte. Elle la fait tournoyer sans fin comme une patate chaude.
-                Peut-être attend-elle qu’elle s'attiédisse? En vain, car elle est
-                faite d’une lave qui ne refroidit pas, elle est tissée du fil de
-                mes traumas, inextricables. Et beaux et fascinants et
-                incandescents comme un astre.
-              </p>
-              <p>
-                Elle roule cette masse sourdement lumineuse, comme la nuit chasse
-                le jour. L’agitation est une lame de fond, un courant profond et
-                puissant qui m’exhorte : “avance, fais plus, fais mieux, surtout
-                ne regarde pas vers le bas.” Pour ne pas être tentée de me jeter
-                dans le noyau ardent du volcan, j’avance, je continue de m’agiter.
-                Si j’essayais de regarder en face et de très près, frontalement
-                donc, la somme de mes traumatismes, ce petit monticule de douleur,
-                j’en mourrais surement, réduite en poudre instantanément. En cela,
-                ma vaillante insecte me protège, elle m’évite la confrontation,
-                elle maintient la souffrance à distance par son activité
-                incessante.
-              </p>
-              <p>
-                Alors quand j’ai fini de travailler, je pense au travail,
-                j’imagine des tableurs me permettant de travailler mieux et plus
-                vite. Ainsi je pourrais dégager du temps pour en faire encore
-                plus. J’ai parfois l’impression de me conduire comme un manager
-                fou, ou un poulet sans tête, ce qui est tout comme.
-              </p>
+              <details>
+                <summary>read more...</summary>
+                <p>
+                  Je suis obstinée. J’abats les taches qu’on me confie. Je fais même
+                  ce que j’avais dit que je refusais de faire, mais je le fais quand
+                  même rattrapée par ma culpabilité congénitale. Bref, j’en fais
+                  beaucoup trop, et c’est la scarabée qui me conduit sur ce chemin.
+                  Pour tenir le trauma à distance, pour maintenir l’illusion d’un
+                  quotidien performant et l’apparence bien ficelée de la normalité.
+                </p>
+                <p>
+                  Elle pousse une boule d’émotions résultant du traumatisme. Elle
+                  incarne ma détermination à m’agiter pour ne pas laisser les
+                  émotions (la peur, la honte, et la tristesse) me pétrifier. Ses
+                  pattes griffues s’arqueboutent sur une sphère plus grosse et plus
+                  lourde qu’elle-même. Les pattes avant campent dans le sol,
+                  cherchent de meilleures prises pour se propulser ; les pattes
+                  arrière roulent sur la boule pour la déplacer. Petit pas par petit
+                  pas, avec opiniâtreté et une forme d’aveuglement d’autant qu’elle
+                  ne progresse qu’à reculons. Imperturbable Sysiphe à 6 pattes, elle
+                  pousse ce rocher, et pousse, et pousse et pousse, sans fin, sans
+                  but. Il est juste impossible de s’arrêter.
+                </p>
+                <p>
+                  La pelote de trauma luit du vermeil d’un volcan ensommeillé, une
+                  chaleur diffuse s’en dégage qui brule le bout des pattes du petit
+                  insecte. Elle la fait tournoyer sans fin comme une patate chaude.
+                  Peut-être attend-elle qu’elle s'attiédisse? En vain, car elle est
+                  faite d’une lave qui ne refroidit pas, elle est tissée du fil de
+                  mes traumas, inextricables. Et beaux et fascinants et
+                  incandescents comme un astre.
+                </p>
+                <p>
+                  Elle roule cette masse sourdement lumineuse, comme la nuit chasse
+                  le jour. L’agitation est une lame de fond, un courant profond et
+                  puissant qui m’exhorte : “avance, fais plus, fais mieux, surtout
+                  ne regarde pas vers le bas.” Pour ne pas être tentée de me jeter
+                  dans le noyau ardent du volcan, j’avance, je continue de m’agiter.
+                  Si j’essayais de regarder en face et de très près, frontalement
+                  donc, la somme de mes traumatismes, ce petit monticule de douleur,
+                  j’en mourrais surement, réduite en poudre instantanément. En cela,
+                  ma vaillante insecte me protège, elle m’évite la confrontation,
+                  elle maintient la souffrance à distance par son activité
+                  incessante.
+                </p>
+                <p>
+                  Alors quand j’ai fini de travailler, je pense au travail,
+                  j’imagine des tableurs me permettant de travailler mieux et plus
+                  vite. Ainsi je pourrais dégager du temps pour en faire encore
+                  plus. J’ai parfois l’impression de me conduire comme un manager
+                  fou, ou un poulet sans tête, ce qui est tout comme.
+                </p>
+              </details>
             </div>
           </article>
           <article id="limace" class="limace">
@@ -648,29 +669,32 @@
                 valeur ne se cache pas dans sa forme, ou dans sa vivacité, mais
                 dans ses qualités intrinsèques.
               </p>
-              <p>
-                Souvent quand j’étais enfant et adolescente, on m’a dit « aller,
-                bouge, mets-toi en mouvement, on dirait une limace sur le canapé
-                ». Limace, limaçonne, molasse, molassonne : l’immobilité ou la
-                lenteur comme repoussoir. Alors j’ai longtemps cru que ma limace
-                devait être cachée ou même combattue, qu’elle était laide et
-                inutile, qu’il valait mieux la dénigrer, ou même nier son
-                existence, l’enfermer dans une boite, l’éventrer d’un coup de
-                botte en caoutchouc dans le jardin pour voir ses entrailles
-                souiller l’herbe. Parfois je me sens limace, grasse, collante,
-                baveuse, lisse, glissante, lente, inutile, ridicule, laide, molle.
-                Je visualise une limace, poisseuse de l’intérieur, éventrée
-                vivante.
-              </p>
-              <p>
-                Cependant, ce n’est pas parce qu’on ressemble à une merde qu’on en
-                est une. Aujourd’hui je vois la beauté de ma limace dans chaque
-                mouvement subtil de ses antennes, dans les dessins raffinés des
-                ridules sur son corps. Je vois sa puissance dans sa capacité à se
-                tracter et se rétracter à la seule force de la ventouse que
-                l’évolution de la vie sur terre lui a donnée. Et je collecte
-                précieusement les paillettes qu’elle étale autour d’elle.
-              </p>
+              <details>
+                <summary>read more...</summary>
+                <p>
+                  Souvent quand j’étais enfant et adolescente, on m’a dit « aller,
+                  bouge, mets-toi en mouvement, on dirait une limace sur le canapé
+                  ». Limace, limaçonne, molasse, molassonne : l’immobilité ou la
+                  lenteur comme repoussoir. Alors j’ai longtemps cru que ma limace
+                  devait être cachée ou même combattue, qu’elle était laide et
+                  inutile, qu’il valait mieux la dénigrer, ou même nier son
+                  existence, l’enfermer dans une boite, l’éventrer d’un coup de
+                  botte en caoutchouc dans le jardin pour voir ses entrailles
+                  souiller l’herbe. Parfois je me sens limace, grasse, collante,
+                  baveuse, lisse, glissante, lente, inutile, ridicule, laide, molle.
+                  Je visualise une limace, poisseuse de l’intérieur, éventrée
+                  vivante.
+                </p>
+                <p>
+                  Cependant, ce n’est pas parce qu’on ressemble à une merde qu’on en
+                  est une. Aujourd’hui je vois la beauté de ma limace dans chaque
+                  mouvement subtil de ses antennes, dans les dessins raffinés des
+                  ridules sur son corps. Je vois sa puissance dans sa capacité à se
+                  tracter et se rétracter à la seule force de la ventouse que
+                  l’évolution de la vie sur terre lui a donnée. Et je collecte
+                  précieusement les paillettes qu’elle étale autour d’elle.
+                </p>
+              </details>
             </div>
           </article>
           <article id="louve-paon" class="louve-paon">
@@ -699,22 +723,25 @@
                 petit pas par petit pas, la métamorphose a opéré. La louve-paon
                 est née de l’amour que j’ai appris à me porter en devenant maman.
               </p>
-              <p>
-                Elle est puissante, fière et féroce, mais aussi délicate et
-                généreuse. De ses pattes de velours, elle me précède, le nez
-                humide et réconfortant flairant les alentours. Sa traine
-                somptueuse ferme la route, efface ses traces. Elle est un dosage
-                élégant d’intelligence et de confiance. Protectrice et
-                chaleureuse, elle s’occupe à merveille des petit.es en tout genre.
-                C’est la pédagogue de ma ménagerie.
-              </p>
-              <p>
-                Lorsque je panique, pour mille et une raison car j’ai l'angoisse
-                facile, c’est elle qui reprend le dessus. Alors je me tourne vers
-                mon enfant, et dans mes yeux c’est sa sécurité qu’il puise. Elle
-                nous enveloppe tous deux de la certitude d’être au bon endroit au
-                bon moment. Sa crinière est un refuge de chaleur et d’amour.
-              </p>
+              <details>
+                <summary>read more...</summary>
+                <p>
+                  Elle est puissante, fière et féroce, mais aussi délicate et
+                  généreuse. De ses pattes de velours, elle me précède, le nez
+                  humide et réconfortant flairant les alentours. Sa traine
+                  somptueuse ferme la route, efface ses traces. Elle est un dosage
+                  élégant d’intelligence et de confiance. Protectrice et
+                  chaleureuse, elle s’occupe à merveille des petit.es en tout genre.
+                  C’est la pédagogue de ma ménagerie.
+                </p>
+                <p>
+                  Lorsque je panique, pour mille et une raison car j’ai l'angoisse
+                  facile, c’est elle qui reprend le dessus. Alors je me tourne vers
+                  mon enfant, et dans mes yeux c’est sa sécurité qu’il puise. Elle
+                  nous enveloppe tous deux de la certitude d’être au bon endroit au
+                  bon moment. Sa crinière est un refuge de chaleur et d’amour.
+                </p>
+              </details>
             </div>
           </article>
         </div>

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
         <div class="navigation__nav">
           <ul class="navigation__list">
             <li class="navigation__item"> <a href="#about-project" class="navigation__link">About Project</a> </li>
-            <li class="navigation__item"> <a href="#infos" class="navigation__link">Synopsis</a> </li>
+            <li class="navigation__item"> <a href="#synopsis" class="navigation__link">Synopsis</a> </li>
             <li class="navigation__item"> <a href="#paintings" class="navigation__link">Peinture et textes</a> </li>
             <li class="navigation__item"> <a href="#sculptures" class="navigation__link">Sculptures</a> </li>
             <li class="navigation__item"> <a href="#infos" class="navigation__link">Infos</a>

--- a/index.html
+++ b/index.html
@@ -117,7 +117,7 @@
           <h2> Créer depuis l'amnésie traumatique : Peintures et poèmes à lire ou écouter </h2>
         </header>
 
-        <nav id="nav-gallery">
+        <nav id="nav-gallery" class="nav-gallery-hidden">
           <ul>
             <a href="#ourson">
               <li class="ourson">

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -9,8 +9,7 @@
   z-index: -1;
   left: 0;
   top: 0;
-  margin-right: 200px;
-  width: 100vw;
+  width: 100%;
   height: 100%;
   opacity: 1;
   background-size: cover;
@@ -168,7 +167,7 @@
   z-index: -2;
   left: 0;
   top: 0;
-  width: 100vw;
+  width: 100%;
   height: 100vh;
   opacity: 0.5;
   background-image: url('../images/background/pattern_terrazzo.png');

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -78,6 +78,7 @@
 #nav-gallery ul figure {
   position: relative;
   margin: 0;
+  padding: 0;
   z-index: 2;
 }
 #nav-gallery ul figure img {

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -118,9 +118,10 @@
 
 #paintings audio {
   display: block;
-  height: 1.5rem;
-  border-radius: 4%/50%;
-  padding-bottom: 0.2rem;
+  align-self: flex-end;
+  transform: translateY(-0.75rem);
+  height: 2rem;
+  border-radius: 5%/50%;
 }
 #paintings audio:hover,
 #paintings audio:focus {

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -13,6 +13,7 @@
   width: 100vw;
   height: 100%;
   opacity: 1;
+  background-size: cover;
   background-repeat: no-repeat;
   background-origin: content-box;
   background-position-x: right;

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -174,6 +174,12 @@
   background-size: cover;
   background-repeat: repeat;
   background-position: center;
+  transition: all 0.1667s ease-in-out;
+  scale: 1.025;
+}
+section:hover ~ #background-image div#background-image-container {
+  transition: all 0.1667s ease-in-out;
+  scale: 1;
 }
 
 /* X

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -193,8 +193,8 @@ footer {
   bottom: 0;
   width: 100%;
   text-align: center;
-  padding: 0 5rem 1rem 0;
-  background-color: transparent;
+  padding: 1rem 0;
+  background-color: var(--dark-background);
 }
 footer p {
   background-color: transparent;

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -135,8 +135,6 @@
 }
 #paintings figure img {
   max-width: 100%;
-  margin-bottom: 1rem;
-  padding-top: 1rem;
   box-shadow: -1px -1px 1px 0 black, 4px 6px 12px 6px black;
 }
 #paintings figure img .paysage {

--- a/public/css/main-navbar.css
+++ b/public/css/main-navbar.css
@@ -56,7 +56,7 @@ html {
           flex-direction: column;
           justify-content: center;
           list-style: none;
-          text-align: center;
+          text-align: left;
         }
         .navigation__item {
           margin: 1rem;

--- a/public/css/text-titles.css
+++ b/public/css/text-titles.css
@@ -5,6 +5,7 @@ h1, h2, h3, h4, h5, h6 {
   text-align: left;
   font-weight: 200;
   line-height: 1.5; 
+  padding: 0;
 }
 h1 {
   font-size: 5rem;


### PR DESCRIPTION
Hi @Oriane, I`ve made many css fixes and implemented the new feature 'read more...' for the painting description as per your request: please check details below.
- aafe4fc (HEAD -> engfabiom/fix/css, origin/engfabiom/fix/css):  fix background width oversizing (Fabio - latest)
- 68c2336: fix footer background, alignment and padding (Fabio)
- e045e80: NEW FEATURE: include '>read more...' details on paintings descriptions (Fabio)
- b067a03: remove bootstrap js as it was commented out and there is no bootstrap css on head tag (Fabio)
- 05d87cf: fix #paintings image shadow effect - removed extra padding that appears on it (Fabio)
- ff05b3b: fix audio size, positioning and hover effect (Fabio)
- d4f0811: fix on nav-gallery - initial display, padding (Fabio)
- 73282d1: fix on home__bgicontainer background image -> cover (Fabio)
- 1bd624c: fix main nav synopsis and left alignment (Fabio)
-   f08af67 (origin/main, origin/HEAD, main): fix color and resize toggle bar (Robo - previous merge)