### PR TITLE
fix view zoomed in on phone

### DIFF
--- a/public/css/global.css
+++ b/public/css/global.css
@@ -35,7 +35,7 @@ html body {
   color: var(--light-purple);
   width: 100%;
   margin: 0 auto;
-  min-width: 400px;
+  min-width: 360px;
 }
 html main {
   margin-left: 10%;
@@ -54,4 +54,4 @@ section {
 
 ul {
   list-style: none;
-}/*# sourceMappingURL=global.css.map */
+} /*# sourceMappingURL=global.css.map */


### PR DESCRIPTION
The website is zoomed in when a user views it through a phone. This was caused by min-widh property. In update, it is scaled down to 380px to make it compatible for phone with smaller screen.